### PR TITLE
Fix Jabbax.Deserializer content-type pattern matching

### DIFF
--- a/lib/jabbax/deserializer.ex
+++ b/lib/jabbax/deserializer.ex
@@ -5,7 +5,7 @@ defmodule Jabbax.Deserializer do
 
   def call(conn = %{body_params: %{}}, _opts) do
     case conn.__struct__.get_req_header(conn, "content-type") do
-      "application/vnd.api+json" -> Map.update!(conn, :body_params, &call/1)
+      ["application/vnd.api+json"] -> Map.update!(conn, :body_params, &call/1)
       _ -> conn
     end
   end

--- a/test/jabbax/deserializer_test.exs
+++ b/test/jabbax/deserializer_test.exs
@@ -329,4 +329,65 @@ defmodule Jabbax.DeserializerTest do
       }
     }
   end
+
+  defmodule JsonApiConn do
+    defstruct body_params: %{}
+
+    def get_req_header(_conn, "content-type") do
+      ["application/vnd.api+json"]
+    end
+  end
+
+  test "JSON API plug behavior" do
+    conn = Deserializer.call(
+      %JsonApiConn{
+        body_params: %{
+          "data" => %{
+            "id" => "1",
+            "type" => "user",
+            "attributes" => %{
+              "name" => "Sample User"
+            }
+          },
+          "jsonapi" => %{
+            "version" => "1.0"
+          }
+        }
+      },
+      %{}
+    )
+
+    assert conn.body_params == %Document{
+      data: %Resource{
+        id: "1",
+        type: "user",
+        attributes: %{
+          "name" => "Sample User"
+        }
+      }
+    }
+  end
+
+  defmodule OtherConn do
+    defstruct body_params: %{}
+
+    def get_req_header(_conn, "content-type") do
+      ["application/json"]
+    end
+  end
+
+  test "non-JSON API plug behavior" do
+    conn = Deserializer.call(
+      %OtherConn{
+        body_params: %{
+          "name" => "Sample User"
+        }
+      },
+      %{}
+    )
+
+    assert conn.body_params == %{
+      "name" => "Sample User"
+    }
+  end
 end


### PR DESCRIPTION
`Plug.Conn.get_req_header/2` returns a *list* of values for a given header as per https://github.com/elixir-lang/plug/blob/master/lib/plug/conn.ex#L523

The pattern matching in Jabbax expects a bare string, which prevented the deserializer from transforming `body_params` even when the `Content-Type` was actually `application/vnd.api+json`.

I'm not sure about versioning in Hex packages, so I'd appreciate some help if this needs a version bump.