### PR TITLE
Make jsonapi key optional as per JSON API spec

### DIFF
--- a/lib/jabbax/deserializer.ex
+++ b/lib/jabbax/deserializer.ex
@@ -152,6 +152,7 @@ defmodule Jabbax.Deserializer do
       version: "1.0"
     }
   end
+  defp dig_and_deserialize_version(_), do: %{version: "1.0"}
 
   defp deserialize_type(type), do: deserialize_key(type)
 

--- a/test/jabbax/deserializer_test.exs
+++ b/test/jabbax/deserializer_test.exs
@@ -390,4 +390,27 @@ defmodule Jabbax.DeserializerTest do
       "name" => "Sample User"
     }
   end
+
+  test "no jsonapi key" do
+    assert Deserializer.call(
+      %{
+        "data" => %{
+          "id" => "1",
+          "type" => "user",
+          "attributes" => %{
+            "name" => "Sample User"
+          }
+        }
+      }
+    ) == %Document{
+      data: %Resource{
+        id: "1",
+        type: "user",
+        attributes: %{
+          "name" => "Sample User"
+        }
+      },
+      jsonapi: %{version: "1.0"}
+    }
+  end
 end


### PR DESCRIPTION
The [JSON API spec](http://jsonapi.org/format/#document-top-level) says the top-level object *MAY* contain a `jsonapi` object with the JSON API version used in the document, yet currently Jabbax throws an error during deserialization of a document without the `jsonapi` key.

Since we only support v1.0 in Jabbax for now, we've decided to default to this version if the key is not present. This is in sync with`Jabbax.Serializer`, where `%{version: "1.0"}` is appended by default.