### PR TITLE
Return empty Jabbax.Document for empty request body

### DIFF
--- a/lib/jabbax/parser.ex
+++ b/lib/jabbax/parser.ex
@@ -14,6 +14,7 @@ if Code.ensure_loaded?(Plug) do
     defp decode({:more, _, conn}), do: {:error, :too_large, conn}
     defp decode({:error, :timeout}), do: raise Plug.TimeoutError
     defp decode({:error, _}), do: raise Plug.BadRequestError
+    defp decode({:ok, "", conn}), do: {:ok, %Jabbax.Document{}, conn}
     defp decode({:ok, body, conn}) do
       {:ok, Jabbax.decode!(body), conn}
     rescue

--- a/test/jabbax/parser_test.exs
+++ b/test/jabbax/parser_test.exs
@@ -52,4 +52,17 @@ defmodule Jabbax.ParserTest do
 
     assert connection.body_params == %{}
   end
+
+  test "empty request body" do
+    connection = conn(:post, "/", "")
+    |> put_req_header("content-type", "application/vnd.api+json")
+    |> parse([Jabbax.Parser])
+
+    assert connection.body_params == %Document{
+      data: nil,
+      jsonapi: %{
+        version: "1.0"
+      }
+    }
+  end
 end


### PR DESCRIPTION
The `Plug.Parsers.JSON` handles the case where the request body is empty, and [returns an empty map in such case](https://github.com/elixir-lang/plug/blob/master/lib/plug/parsers/json.ex#L42).

Me and @detfis think `Jabbax.Parser` should return an empty `Jabbax.Document` in such cases. This is compliant with JSON API specification and allows for no-content requests to the server like some `DELETE` requests.