### PR TITLE
Allow nil data attribute in relationships

### DIFF
--- a/lib/jabbax/serializer.ex
+++ b/lib/jabbax/serializer.ex
@@ -83,6 +83,7 @@ defmodule Jabbax.Serializer do
     |> dig_and_serialize_meta
     |> dig_and_serialize_links
     |> struct_to_map_with_present_keys
+    |> put_empty_data
   end
   defp serialize_relationship(data) when is_list(data) or is_map(data) do
     %{

--- a/test/jabbax/serializer_test.exs
+++ b/test/jabbax/serializer_test.exs
@@ -219,6 +219,36 @@ defmodule Jabbax.SerializerTest do
         version: "1.0"
       }
     }
+
+    assert Serializer.call(
+      %Document{
+        data: %Resource{
+          id: "1",
+          type: "employees",
+          relationships: %{
+            business: %Relationship{
+              data: nil
+            }
+          }
+        },
+        jsonapi: %{
+          version: "1.0"
+        }
+      }
+    ) == %{
+      data: %{
+        id: "1",
+        type: "employees",
+        relationships: %{
+          "business" => %{
+            data: nil
+          }
+        }
+      },
+      jsonapi: %{
+        version: "1.0"
+      }
+    }
   end
 
   test "errors" do


### PR DESCRIPTION
The main `data` object allows for `{ data: null }`, but it is not the case in relationships, where empty attributes are filtered out. [According to JSON API spec](http://jsonapi.org/format/#document-resource-object-linkage) we should allow for `{ data: null }` in relationships.