### PR TITLE
Remove duplicate behaviour declaration

### DIFF
--- a/lib/jabbax/structure_error.ex
+++ b/lib/jabbax/structure_error.ex
@@ -1,6 +1,4 @@
 defmodule Jabbax.StructureError do
-  @behaviour Exception
-
   defexception [:context, :expected, :actual]
 
   def message(error) do

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,5 @@
-%{"mime": {:hex, :mime, "1.1.0", "01c1d6f4083d8aa5c7b8c246ade95139620ef8effb009edde934e0ec3b28090a", [:mix], []},
-  "plug": {:hex, :plug, "1.3.5", "7503bfcd7091df2a9761ef8cecea666d1f2cc454cbbaf0afa0b6e259203b7031", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1", [hex: :cowboy, optional: true]}, {:mime, "~> 1.0", [hex: :mime, optional: false]}]},
-  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], []}}
+%{
+  "mime": {:hex, :mime, "1.1.0", "01c1d6f4083d8aa5c7b8c246ade95139620ef8effb009edde934e0ec3b28090a", [:mix], [], "hexpm", "33dd09e615daab5668c15cc3a33829892728fdbed910ab0c0a0edb06b45fc54d"},
+  "plug": {:hex, :plug, "1.3.5", "7503bfcd7091df2a9761ef8cecea666d1f2cc454cbbaf0afa0b6e259203b7031", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm", "141058cca1fa800128391ece7f442f71a7b42a7411e6eaa56dc8f85283c8dde7"},
+  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm", "fec8660eb7733ee4117b85f55799fd3833eb769a6df71ccf8903e8dc5447cfce"},
+}


### PR DESCRIPTION
Using `defexception` declares the module as implementing `Exception` behaviour automatically. Duplicating it with explicit declaration leads to compilation warnings:

```
==> jabbax
Compiling 13 files (.ex)
warning: the behavior Exception has been declared twice (conflict in function message/1 in module Jabbax.StructureError)
  lib/jabbax/structure_error.ex:1: Jabbax.StructureError (module)

warning: the behavior Exception has been declared twice (conflict in function exception/1 in module Jabbax.StructureError)
  lib/jabbax/structure_error.ex:1: Jabbax.StructureError (module)

warning: the behavior Exception has been declared twice (conflict in function blame/2 in module Jabbax.StructureError)
  lib/jabbax/structure_error.ex:1: Jabbax.StructureError (module)
```

See https://github.com/elixir-lang/elixir/blob/03859fb92edc56a1cb5d7436b6bec282156198dc/lib/elixir/lib/kernel.ex#L4969

This also changes `mix.lock` to use a modern format.