### PR TITLE
Handle malformed body

### DIFF
--- a/lib/jabbax/plug.ex
+++ b/lib/jabbax/plug.ex
@@ -16,6 +16,9 @@ if Code.ensure_loaded?(Plug) do
         _ ->
           conn
       end
+    rescue
+      # credo:disable-for-next-line Credo.Check.Warning.RaiseInsideRescue
+      e in Jabbax.StructureError -> raise Plug.Parsers.ParseError, exception: e
     end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Jabbax.Mixfile do
   def project do
     [
       app: :jabbax,
-      version: "0.2.0",
+      version: "0.2.1",
       elixir: "~> 1.4",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,

--- a/test/jabbax/deserializer_test.exs
+++ b/test/jabbax/deserializer_test.exs
@@ -2,6 +2,7 @@ defmodule Jabbax.DeserializerTest do
   use ExUnit.Case
   use Jabbax.Document
   alias Jabbax.Deserializer
+  alias Jabbax.StructureError
 
   test "one resource, attributes, relationships, meta, links and includes" do
     assert Deserializer.call(%{
@@ -260,6 +261,57 @@ defmodule Jabbax.DeserializerTest do
                version: "1.0"
              }
            }
+  end
+
+  test "new documents with invalid nil relationships" do
+    assert_raise(StructureError, fn ->
+      Deserializer.call(%{
+        "data" => %{
+          "type" => "employees",
+          "relationships" => nil
+        },
+        "jsonapi" => %{
+          "version" => "1.0"
+        }
+      })
+    end)
+  end
+
+  test "new documents with invalid relationship object dataaa" do
+    assert_raise(StructureError, fn ->
+      Deserializer.call(%{
+        "data" => %{
+          "type" => "employees",
+          "relationships" => %{
+            "service" => %{
+              "dataaa" => %{
+                "type" => "services",
+                "id" => "21"
+              }
+            }
+          }
+        },
+        "jsonapi" => %{
+          "version" => "1.0"
+        }
+      })
+    end)
+  end
+
+  test "new documents with invalid relationship list" do
+    assert_raise(StructureError, fn ->
+      Deserializer.call(%{
+        "data" => %{
+          "type" => "employees",
+          "relationships" => [
+            ""
+          ]
+        },
+        "jsonapi" => %{
+          "version" => "1.0"
+        }
+      })
+    end)
   end
 
   test "empty data" do

--- a/test/jabbax/plug_test.exs
+++ b/test/jabbax/plug_test.exs
@@ -63,4 +63,31 @@ defmodule Jabbax.PlugTest do
 
     assert connection.assigns[:custom_doc] == nil
   end
+
+  test "malformed body" do
+    malformed_body = %{
+      "data" => %{
+        "type" => "employees",
+        "relationships" => %{
+          "service" => %{
+            "dataaa" => %{
+              "type" => "services",
+              "id" => "21"
+            }
+          }
+        }
+      },
+      "jsonapi" => %{
+        "version" => "1.0"
+      }
+    }
+
+    assert_raise(Plug.Parsers.ParseError, fn ->
+      :post
+      |> conn("/", Poison.encode!(malformed_body))
+      |> put_req_header("content-type", "application/vnd.api+json")
+      |> parse([Jabbax.Parser])
+      |> Jabbax.Plug.call(Jabbax.Plug.init(nil))
+    end)
+  end
 end


### PR DESCRIPTION
## Description

We want to better handle the malformed body of a [JSON API](https://jsonapi.org/format/) request.

When an invalid body is passed to be parsed the correct approach should be to raise `Plug.Parsers.ParseError` which will be replaced with the 400 error returned to the client, instead of raising the 500 error on the server.

[Plug.Parser](https://hexdocs.pm/plug/Plug.Parsers.html)
[Plug.Parsers.ParseError](https://hexdocs.pm/plug/Plug.Parsers.ParseError.html)