### PR TITLE
CD-619 elixir-orb update - postgres circleci convience img update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  elixir-orb: fresha/elixir-orb@0.0
+  elixir-orb: fresha/elixir-orb@0.2
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,8 @@ workflows:
   version: 2
   ci:
     jobs:
-      - elixir-orb/test
+      - elixir-orb/test:
+          context: Hex
       - elixir-orb/static-check:
           dialyzer: true
           context: Hex


### PR DESCRIPTION
Addresses [CD-619](https://shedul.atlassian.net/browse/CD-619).

## Overview
Update of elixir-orb for circleci usage from 0.0 -> 0.2
- Only change between 0.1 -> 0.2 is an updated postgres image and a new command.
image: 'circleci/postgres:12-postgis-ram' -> image: 'cimg/postgres:12.9-postgis' (https://github.com/surgeventures/elixir-orb/pull/14/files), both images running postgres 12.9
- Few more changes in 0.0 -> 0.1

This is related to the deprecation of the legacy convenience images from circleci (circleci/ -> next-gen cimg/) from Dec 2021
